### PR TITLE
Allow custom data directories

### DIFF
--- a/Programs/README.md
+++ b/Programs/README.md
@@ -1,3 +1,7 @@
 # Programs
 
-Experimental scripts and Slurm drivers live here. The `Reordering` and `Multiplication` folders hold wrapper scripts for each technique or kernel listed in `TOOLS.md`. Global environment variables are configured in `exp_config.sh`.
+Experimental scripts and Slurm drivers live here. The `Reordering` and `Multiplication` folders hold wrapper scripts for each technique or kernel listed in `TOOLS.md`.
+
+Runtime paths are also configured in `exp_config.sh`.  Set the `MATRIX_DIR`
+and `RESULTS_DIR` environment variables before sourcing it if you want to
+store the dataset or experiment output outside the repository.

--- a/Programs/exp_config.sh
+++ b/Programs/exp_config.sh
@@ -1,3 +1,13 @@
-# Placeholder cluster-wide environment and path definitions
-# TODO: customize module loads and environment variables
+# Cluster-wide environment and path definitions
+
+# Determine the absolute project root (one level up from this file)
+export PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Allow overriding dataset and result locations.  By default both
+# directories live inside the repository, but large deployments can
+# point them elsewhere before sourcing this file.
+export MATRIX_DIR="${MATRIX_DIR:-$PROJECT_ROOT/Raw_Matrices}"
+export RESULTS_DIR="${RESULTS_DIR:-$PROJECT_ROOT/Results}"
+
+# TODO: add module loads and other environment variables below
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ This repository hosts an experimental framework for studying how matrix reorderi
 - `logs/` – Slurm job output.
 
 See `TODO.md` for the current development status and upcoming tasks.
+
+## Customizing Data Locations
+
+By default the matrices and experiment results reside under `Raw_Matrices/` and
+`Results/` inside the repository.  Large deployments can place these folders
+elsewhere by exporting `MATRIX_DIR` and `RESULTS_DIR` before sourcing
+`Programs/exp_config.sh`.

--- a/Raw_Matrices/README.md
+++ b/Raw_Matrices/README.md
@@ -1,3 +1,6 @@
 # Raw_Matrices
 
 This directory will contain the unmodified matrices fetched from the SuiteSparse Matrix Collection. The contents are static after the initial download and should not be versioned with Git if large. Use the provided scripts to sync the dataset.
+
+You can store the matrices outside the repository by defining the
+`MATRIX_DIR` environment variable before sourcing `Programs/exp_config.sh`.

--- a/Results/README.md
+++ b/Results/README.md
@@ -1,3 +1,6 @@
 # Results
 
 This directory gathers experiment outputs. Each phase writes CSV files under the subfolders `Reordering` and `Multiplication`.
+
+Set the `RESULTS_DIR` environment variable prior to sourcing
+`Programs/exp_config.sh` if you want to place these outputs elsewhere.


### PR DESCRIPTION
## Summary
- define `MATRIX_DIR` and `RESULTS_DIR` in `exp_config.sh`
- document how to override these paths in READMEs

## Testing
- `bash scripts/bootstrap.sh`
- `python -m py_compile scripts/csv_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68878faa4dd48321a2d286540ca64856