### PR TITLE
Add Rabbit Order bootstrap instructions

### DIFF
--- a/Programs/Reordering/Techniques/README.md
+++ b/Programs/Reordering/Techniques/README.md
@@ -1,1 +1,27 @@
-Scripts implementing individual reordering techniques belong here. See `TOOLS.md` for the list of expected handles.
+# Reordering Techniques
+
+This directory contains wrapper scripts and installation notes for each
+reordering algorithm listed in `TOOLS.md`.
+
+## Rabbit Order (`ro`)
+
+The Rabbit Order sources are retrieved during the bootstrap stage. Ensure `gcc`,
+`boost`, `libnuma`, and `google-perftools` are installed on your system.
+
+### Build steps
+
+1. Clone the repository into `build/rabbit_order`:
+
+   ```bash
+   git clone --depth 1 https://github.com/araij/rabbit_order.git \
+       "$PROJECT_ROOT/build/rabbit_order"
+   git -C "$PROJECT_ROOT/build/rabbit_order" checkout f67a79e427e2a06e72f6b528fd5464dfe8a43174
+   ```
+2. Compile the demo program which outputs the permutation:
+
+   ```bash
+   make -C "$PROJECT_ROOT/build/rabbit_order/demo"
+   ```
+
+The wrapper `reordering_ro.sh` expects the resulting binary at
+`$PROJECT_ROOT/build/rabbit_order/demo/reorder`.

--- a/Programs/Reordering/Techniques/reordering_ro.sh
+++ b/Programs/Reordering/Techniques/reordering_ro.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# reordering_ro.sh <matrix> <out_perm> <params_json>
+set -euo pipefail
+
+# Load cluster environment
+source "$(dirname "$0")/../../exp_config.sh"
+
+RO_BIN="$PROJECT_ROOT/build/rabbit_order/demo/reorder"
+
+if [[ ! -x "$RO_BIN" ]]; then
+    echo "Rabbit Order binary not found at $RO_BIN" >&2
+    exit 1
+fi
+
+mode=$(python - <<'PY'
+import json,sys
+with open(sys.argv[1]) as f:
+    p=json.load(f)
+print(p.get('mode','reorder'))
+PY
+"$3")
+
+flag=""
+if [[ "$mode" == "cluster" ]]; then
+    flag="-c"
+fi
+
+"$RO_BIN" $flag "$1" | awk '{print $1+1}' > "$2"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ By default the matrices and experiment results reside under `Raw_Matrices/` and
 `Results/` inside the repository.  Large deployments can place these folders
 elsewhere by exporting `MATRIX_DIR` and `RESULTS_DIR` before sourcing
 `Programs/exp_config.sh`.
+
+## Installing Reordering Techniques
+
+Run `scripts/bootstrap.sh` to fetch and build external reorderers. Detailed
+instructions for each tool are found in `Programs/Reordering/Techniques/README.md`.

--- a/config/reorder.yml
+++ b/config/reorder.yml
@@ -1,4 +1,6 @@
 # Placeholder reordering parameter sets
 rcm:
   - param: default
+ro:
+  - param: default
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
-# Placeholder script for cloning dependencies and building third-party tools
+# Clone and compile third-party reordering libraries
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+mkdir -p "$BUILD"
+
+# Rabbit Order ---------------------------------------------------------------
+RO_DIR="$BUILD/rabbit_order"
+if [[ ! -d "$RO_DIR" ]]; then
+    git clone --depth 1 https://github.com/araij/rabbit_order.git "$RO_DIR"
+    git -C "$RO_DIR" checkout f67a79e427e2a06e72f6b528fd5464dfe8a43174
+fi
+make -C "$RO_DIR/demo"
 


### PR DESCRIPTION
## Summary
- document where to find installation steps for reordering tools
- detail Rabbit Order build instructions
- add wrapper `reordering_ro.sh`
- include Rabbit Order in default config
- bootstrap script clones and compiles Rabbit Order

## Testing
- `shellcheck -e SC1091 Programs/Reordering/Techniques/reordering_ro.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887913c4cf08321b2bd3412c3b1298d