### PR TITLE
Switch csv helper to GraphBLAS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ project_root/
 ./scripts/bootstrap.sh   # wraps git clone & cmake
 # 2. create Python venv + requirements.txt
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt  # numpy, pandas, scipy, suitesparsegraphblas, py-metis
+pip install -r requirements.txt  # numpy, pandas, scipy, python-graphblas, py-metis
 # 3. verify GPU toolkits
 nvcc --version  # expect ≥12.2
 nvidia-smi      # driver ≥550.XX

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ instructions for each tool are found in `Programs/Reordering/Techniques/README.m
 
 ## Python Environment
 
-Helper scripts such as `csv_helper.py` rely on SciPy's sparse matrix
-functions. Create a virtual environment and install the Python
-dependencies before running the pipeline:
+Helper scripts such as `csv_helper.py` use SuiteSparse:GraphBLAS for
+sparse matrix operations. Create a virtual environment and install the
+Python dependencies before running the pipeline:
 
 ```bash
 python -m venv .venv
@@ -37,4 +37,4 @@ pip install -r requirements.txt
 ```
 
 The `requirements.txt` file lists `numpy`, `pandas`, `scipy`,
-`suitesparsegraphblas`, and `py-metis`.
+`python-graphblas`, and `py-metis`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pandas
 scipy
-suitesparsegraphblas
+python-graphblas
 py-metis

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 Helper utilities and setup scripts. `bootstrap.sh` installs third-party
 reorderers. `csv_helper.py` merges structural metrics into the results and
-uses SciPy for sparse matrix computations. Install the Python packages
+uses SuiteSparse:GraphBLAS for sparse matrix computations. Install the Python packages
 listed in `requirements.txt` before invoking these scripts:
 
 ```bash

--- a/scripts/csv_helper.py
+++ b/scripts/csv_helper.py
@@ -2,9 +2,9 @@
 
 This utility reads the original matrix, the permutation produced by a
 reordering technique, and the CSV row emitted by the wrapper script.
-Using SciPy's sparse matrix routines it calculates the half-bandwidth
-and block-level densities (4x4, 8x8, 16x16).  The metrics are written
-back into the same CSV file.
+Using SuiteSparse:GraphBLAS it calculates the half-bandwidth and
+block-level densities (4x4, 8x8, 16x16).  The metrics are written back
+into the same CSV file.
 """
 
 from __future__ import annotations
@@ -15,31 +15,64 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from scipy import io, sparse
+import graphblas as gb
 
 
-def compute_bandwidth(a: sparse.spmatrix) -> int:
+def read_mm(path: Path) -> gb.Matrix:
+    """Load a Matrix Market file into a GraphBLAS matrix."""
+    with open(path) as f:
+        header = f.readline().strip().split()
+        if len(header) < 5 or header[0] != "%%MatrixMarket":
+            raise ValueError("invalid Matrix Market file")
+        symmetry = header[4].lower()
+        for line in f:
+            if line.startswith("%"):
+                continue
+            nrows, ncols, _ = map(int, line.split())
+            break
+        data = np.loadtxt(f)
+    if data.ndim == 1:
+        data = np.array([data])
+    row = data[:, 0].astype(np.int64) - 1
+    col = data[:, 1].astype(np.int64) - 1
+    val = data[:, 2] if data.shape[1] > 2 else np.ones(len(row))
+    if symmetry != "general":
+        mask = row != col
+        row = np.concatenate([row, col[mask]])
+        col = np.concatenate([col, row[mask]])
+        val = np.concatenate([val, val[mask]])
+    return gb.Matrix.from_coo(row, col, val, nrows=nrows, ncols=ncols)
+
+
+def compute_bandwidth(a: gb.Matrix) -> int:
     """Return the half-bandwidth of ``a``."""
-    if a.nnz == 0:
+    if a.nvals == 0:
         return 0
-    rows, cols = a.nonzero()
+    rows, cols, _ = a.to_coo()
+    rows = rows.astype(np.int64)
+    cols = cols.astype(np.int64)
     return int(np.abs(rows - cols).max())
 
 
-def block_metrics(a: sparse.spmatrix, block: int) -> float:
+def block_metrics(a: gb.Matrix, block: int) -> float:
     """Return density of non-empty ``block``×``block`` tiles."""
-    rows, cols = a.nonzero()
+    rows, cols, _ = a.to_coo()
+    if rows.size == 0:
+        return 0.0
+    rows = rows.astype(np.int64)
+    cols = cols.astype(np.int64)
     br = rows // block
     bc = cols // block
-    unique = len({(r, c) for r, c in zip(br, bc)})
-    total = ((a.shape[0] + block - 1) // block) * ((a.shape[1] + block - 1) // block)
+    pairs = np.stack([br, bc], axis=1)
+    unique = np.unique(pairs, axis=0).shape[0]
+    total = ((a.nrows + block - 1) // block) * ((a.ncols + block - 1) // block)
     return unique / total if total else 0.0
 
 
 def main(matrix: Path, perm: Path, csv: Path) -> None:
-    A = io.mmread(matrix).tocsr()
+    A = read_mm(matrix)
     p = np.loadtxt(perm, dtype=np.int64) - 1
-    A = A[p, :][:, p]
+    A = A[p, :][:, p].new()
 
     bw = compute_bandwidth(A)
     densities = {b: block_metrics(A, b) for b in (4, 8, 16)}


### PR DESCRIPTION
## Summary
- rewrite `scripts/csv_helper.py` to use SuiteSparse:GraphBLAS
- update docs to mention GraphBLAS instead of SciPy for csv_helper
- update package name in requirements and installation instructions

## Testing
- `python -m py_compile scripts/csv_helper.py`

------
https://chatgpt.com/codex/tasks/task_e_68879c40b8bc8321a406b5f3f3a9431b