### PR TITLE
Add Slurm driver scripts

### DIFF
--- a/Programs/Multiply.sbatch
+++ b/Programs/Multiply.sbatch
@@ -1,0 +1,71 @@
+#!/bin/bash
+#SBATCH -A hpc
+#SBATCH -t 02:00:00
+#SBATCH -N 1
+#SBATCH --cpus-per-task=32
+# SBATCH --gpus-per-task=1   # enable for GPU kernels
+# Driver for multiplication experiments. Each task reads a line from
+# $TASK_FILE containing: <matrix_dir> <perm_path> <mult_impl> <param_json>
+
+set -euo pipefail
+
+source "$(dirname "$0")/exp_config.sh"
+
+if [[ -z "${TASK_FILE:-}" ]]; then
+    echo "TASK_FILE not specified" >&2
+    exit 1
+fi
+
+IFS=' ' read -r MAT_DIR PERM IMPL PARAM_JSON < <(sed -n "$((SLURM_ARRAY_TASK_ID+1))p" "$TASK_FILE")
+
+if [[ -z "$MAT_DIR" || -z "$PERM" || -z "$IMPL" || -z "$PARAM_JSON" ]]; then
+    echo "Invalid task specification at index $SLURM_ARRAY_TASK_ID" >&2
+    exit 1
+fi
+
+MATRIX_NAME=$(basename "$(dirname "$MAT_DIR")")
+TECH_PARAM=$(basename "$MAT_DIR")
+PARAM_ID=$(basename "$PARAM_JSON" .json)
+
+OUTDIR="$RESULTS_DIR/Multiplication/$MATRIX_NAME/$TECH_PARAM/$IMPL"
+mkdir -p "$OUTDIR"
+CSV="$OUTDIR/results.csv"
+
+WRAPPER="$PROJECT_ROOT/Programs/Multiplication/Techniques/operation_${IMPL}.sh"
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "Wrapper $WRAPPER not found" >&2
+    exit 1
+fi
+
+PARAM_SET=$(python - <<'PY'
+import json,sys
+with open(sys.argv[1]) as f:
+    cfg=json.load(f)
+print(';'.join(f"{k}={v}" for k,v in sorted(cfg.items())))
+PY
+"$PARAM_JSON")
+
+cp "$MAT_DIR/results.csv" "$CSV"
+
+start=$(date +%s%N)
+set +e
+"$WRAPPER" "$MAT_DIR" "$PARAM_JSON"
+STATUS=$?
+set -e
+end=$(date +%s%N)
+TIME_MS=$(( (end - start) / 1000000 ))
+TIMESTAMP=$(date --iso-8601=seconds)
+
+python - <<'PY' "$CSV" "$IMPL" "$PARAM_SET" "$TIME_MS" "$STATUS" "$TIMESTAMP"
+import sys,pandas as pd
+csv,impl,param_set,time_ms,status,timestamp=sys.argv[1:7]
+df=pd.read_csv(csv)
+df['mult_type']=impl
+df['mult_param_set']=param_set
+df['mult_time_ms']=float(time_ms)
+df['exit_code']=int(status)
+df['timestamp']=timestamp
+df.to_csv(csv,index=False)
+PY
+
+exit $STATUS

--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -1,0 +1,84 @@
+#!/bin/bash
+#SBATCH -A hpc
+#SBATCH -t 02:00:00
+#SBATCH -N 1
+#SBATCH --cpus-per-task=32
+# SBATCH --gpus-per-task=1   # enable for GPU-aware reorderers
+# General driver for reordering experiments. Each task reads a line from
+# $TASK_FILE containing: <matrix_path> <reorder_tech> <param_json>
+
+set -euo pipefail
+
+# Ensure PROJECT_ROOT, MATRIX_DIR, RESULTS_DIR
+source "$(dirname "$0")/exp_config.sh"
+
+if [[ -z "${TASK_FILE:-}" ]]; then
+    echo "TASK_FILE not specified" >&2
+    exit 1
+fi
+
+# Extract arguments for this array task
+IFS=' ' read -r MATRIX TECH PARAM_JSON < <(sed -n "$((SLURM_ARRAY_TASK_ID+1))p" "$TASK_FILE")
+
+if [[ -z "$MATRIX" || -z "$TECH" || -z "$PARAM_JSON" ]]; then
+    echo "Invalid task specification at index $SLURM_ARRAY_TASK_ID" >&2
+    exit 1
+fi
+
+MATRIX_NAME=$(basename "$MATRIX" .mtx)
+DATASET=$(basename "$(dirname "$MATRIX")")
+PARAM_ID=$(basename "$PARAM_JSON" .json)
+
+OUTDIR="$RESULTS_DIR/Reordering/$MATRIX_NAME/${TECH}_${PARAM_ID}"
+mkdir -p "$OUTDIR"
+PERM="$OUTDIR/permutation.g"
+CSV="$OUTDIR/results.csv"
+
+WRAPPER="$PROJECT_ROOT/Programs/Reordering/Techniques/reordering_${TECH}.sh"
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "Wrapper $WRAPPER not found" >&2
+    exit 1
+fi
+
+# Convert param JSON to semicolon-separated key=value
+PARAM_SET=$(python - <<'PY'
+import json,sys
+with open(sys.argv[1]) as f:
+    cfg=json.load(f)
+print(';'.join(f"{k}={v}" for k,v in sorted(cfg.items())))
+PY
+"$PARAM_JSON")
+
+start=$(date +%s%N)
+set +e
+"$WRAPPER" "$MATRIX" "$PERM" "$PARAM_JSON"
+STATUS=$?
+set -e
+default=0
+end=$(date +%s%N)
+TIME_MS=$(( (end - start) / 1000000 ))
+TIMESTAMP=$(date --iso-8601=seconds)
+
+# Extract basic matrix info
+read N_ROWS N_COLS NNZ < <(python - <<'PY'
+import sys
+with open(sys.argv[1]) as f:
+    header=f.readline()
+    for line in f:
+        if line.startswith('%'):
+            continue
+        print(*line.split())
+        break
+PY
+"$MATRIX")
+
+# Write initial CSV row
+cat > "$CSV" <<CSV
+matrix_name,dataset,n_rows,n_cols,nnz,reorder_type,reorder_tech,reord_param_set,reorder_time_ms,bandwidth,block_density,exit_code,timestamp
+$MATRIX_NAME,$DATASET,$N_ROWS,$N_COLS,$NNZ,1D,$TECH,"$PARAM_SET",$TIME_MS,,,$STATUS,$TIMESTAMP
+CSV
+
+# Post-process structural metrics
+python "$PROJECT_ROOT/scripts/csv_helper.py" "$MATRIX" "$PERM" "$CSV" || true
+
+exit $STATUS

--- a/TODO.md
+++ b/TODO.md
@@ -4,15 +4,15 @@
 - Established initial folder hierarchy as outlined in `AGENTS.md`.
 - Added README files describing the purpose of each directory.
 - Created placeholders for `exp_config.sh`, helper scripts, and YAML configuration files.
+- Developed the Slurm driver scripts for both pipeline phases.
 
 ## Next Steps
 1. Implement wrapper scripts for each reordering technique and multiplication kernel listed in `TOOLS.md`.
 2. Flesh out `exp_config.sh` with module loads and environment setup.
 3. Populate `config/reorder.yml` and `config/multiply.yml` with real parameter sets.
-4. Develop the Slurm driver scripts for both pipeline phases.
-5. Write code in `scripts/csv_helper.py` to merge structural metrics into the results CSVs.
-6. Add documentation on how to run the bootstrap process and execute the pipeline.
-7. Add an `reordering_identity.sh` wrapper that outputs the identity permutation and writes a minimal `results.csv` for local tests.
-8. Create an `operation_mock.sh` multiplication wrapper that emits fake timing metrics while matching the results CSV schema.
-9. Register these mock techniques in the YAML config files and mention them in the documentation for local runs.
+4. Write code in `scripts/csv_helper.py` to merge structural metrics into the results CSVs.
+5. Add documentation on how to run the bootstrap process and execute the pipeline.
+6. Add an `reordering_identity.sh` wrapper that outputs the identity permutation and writes a minimal `results.csv` for local tests.
+7. Create an `operation_mock.sh` multiplication wrapper that emits fake timing metrics while matching the results CSV schema.
+8. Register these mock techniques in the YAML config files and mention them in the documentation for local runs.
 


### PR DESCRIPTION
## Summary
- Add Slurm array drivers for reordering and multiplication phases
- Track completion of driver scripts in TODO

## Testing
- `bash -n Programs/Reorder.sbatch Programs/Multiply.sbatch`
- `python -m py_compile scripts/csv_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_688df183ad508321b89faa5f3ad8be72