### PR TITLE
Add 2D symmetric reordering support

### DIFF
--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -40,6 +40,16 @@ if [[ ! -x "$WRAPPER" ]]; then
     exit 1
 fi
 
+# Determine reordering type (1D vs 2D)
+REORDER_TYPE=$(python - <<'PY'
+import sys, yaml
+tech, cfg_path = sys.argv[1], sys.argv[2]
+with open(cfg_path) as f:
+    cfg = yaml.safe_load(f)
+print(cfg.get(tech, {}).get('type', '1D'))
+PY
+"$TECH" "$PROJECT_ROOT/config/reorder.yml")
+
 # Convert param JSON to semicolon-separated key=value
 PARAM_SET=$(python - <<'PY'
 import json,sys
@@ -75,7 +85,7 @@ PY
 # Write initial CSV row
 cat > "$CSV" <<CSV
 matrix_name,dataset,n_rows,n_cols,nnz,reorder_type,reorder_tech,reord_param_set,reorder_time_ms,bandwidth,block_density,exit_code,timestamp
-$MATRIX_NAME,$DATASET,$N_ROWS,$N_COLS,$NNZ,1D,$TECH,"$PARAM_SET",$TIME_MS,,,$STATUS,$TIMESTAMP
+$MATRIX_NAME,$DATASET,$N_ROWS,$N_COLS,$NNZ,$REORDER_TYPE,$TECH,"$PARAM_SET",$TIME_MS,,,$STATUS,$TIMESTAMP
 CSV
 
 # Post-process structural metrics

--- a/config/README.md
+++ b/config/README.md
@@ -1,2 +1,4 @@
 Configuration files describing available reordering and multiplication techniques. Edit these YAML files to add new parameter sets.
 
+For reordering, each entry in `reorder.yml` specifies a `type` of `1D` or `2D` to denote whether the permutation is applied only to rows or symmetrically to both rows and columns.
+

--- a/config/reorder.yml
+++ b/config/reorder.yml
@@ -1,7 +1,13 @@
 # Placeholder reordering parameter sets
 rcm:
-  - param: default
+  type: 2D
+  params:
+    - param: default
 ro:
-  - param: default
+  type: 1D
+  params:
+    - param: default
 identity:
-  - param: default
+  type: 1D
+  params:
+    - param: default

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 scipy
 python-graphblas
 py-metis
+pyyaml

--- a/scripts/csv_helper.py
+++ b/scripts/csv_helper.py
@@ -72,12 +72,18 @@ def block_metrics(a: gb.Matrix, block: int) -> float:
 def main(matrix: Path, perm: Path, csv: Path) -> None:
     A = read_mm(matrix)
     p = np.loadtxt(perm, dtype=np.int64) - 1
-    A = A[p, :][:, p].new()
+
+    df = pd.read_csv(csv)
+    rtype = str(df.loc[0, "reorder_type"]).strip().upper() if "reorder_type" in df.columns else "1D"
+
+    if rtype == "2D":
+        A = A[p, :][:, p].new()
+    else:
+        A = A[p, :].new()
 
     bw = compute_bandwidth(A)
     densities = {b: block_metrics(A, b) for b in (4, 8, 16)}
 
-    df = pd.read_csv(csv)
     if "bandwidth" not in df.columns:
         df["bandwidth"] = np.nan
     if "block_density" not in df.columns:


### PR DESCRIPTION
## Summary
- allow specifying reordering type per technique in `config/reorder.yml`
- update driver and helper scripts to handle 2D symmetric permutations
- document new config field and add PyYAML dependency

## Testing
- `python -m py_compile scripts/csv_helper.py`
- `bash -n Programs/Reorder.sbatch`
- `python config/reorder.yml load test`
- `python scripts/csv_helper.py --help` *(fails: No module named 'graphblas')*


------
https://chatgpt.com/codex/tasks/task_e_688df493ffb08321a7ef7802e91a45be