### PR TITLE
refactor sbatch drivers for single-task runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@
       └── installs repos    └── produces .g & CSV      └── writes CSV
 ```
 
-Each stage is launched through an **sbatch driver** and may itself spawn job arrays for scalability.
+Each stage is launched through an **sbatch driver**; submit one job per matrix,
+technique, and parameter set when sweeping experiments.
 
 ### 2.1 Bootstrap (once per cluster)
 
@@ -43,11 +44,12 @@ Each slurm job should first install all needed modules
 
 ### 2.2 Reordering Phase
 
-* **Driver:** `Programs/Reorder.sbatch` (job array on matrices × techniques × param‑sets).
+* **Driver:** `Programs/Reorder.sbatch` (one matrix × technique × param‑set per
+  submission).
 * **Per‑task input**
-  `matrix_path reorder_tech param_set_id`
+  `matrix_path reorder_tech [key=value ...]`
 * **Wrapper contract**
-  `reordering_<tech>.sh  <mtx>  <permutation.g>  <param_json>`
+  `reordering_<tech>.sh  <mtx>  <permutation.g>  [key=value ...]`
 * **Outputs**
 
 ```
@@ -60,11 +62,12 @@ Results/Reordering/<MATRIX>/<TECH>_<PARAMSET>/
 
 ### 2.3 Multiplication Phase
 
-* **Driver:** `Programs/Multiply.sbatch` (job array over reordered matrices × kernels × params).
+* **Driver:** `Programs/Multiply.sbatch` (one reordered matrix × kernel × param
+  set per submission).
 * **Per‑task input**
-  `matrix_dir matrix_permutation mult_impl param_set_id`
+  `matrix_dir matrix_permutation mult_impl [key=value ...]`
 * **Wrapper contract**
-  `operation_<impl>.sh <matrix_dir>  <param_json>`
+  `operation_<impl>.sh <matrix_dir>  [key=value ...]`
 * **Outputs**
 
 ```

--- a/Programs/Multiply.sbatch
+++ b/Programs/Multiply.sbatch
@@ -15,24 +15,23 @@
 
 
 
-# Driver for multiplication experiments. Each task reads a line from
-# $TASK_FILE containing: <matrix_dir> <perm_path> <mult_impl> <param_json>
+# Driver for a single multiplication experiment.
+# Usage: sbatch Programs/Multiply.sbatch <matrix_dir> <perm_path> <mult_impl> [key=value ...]
 
 set -euo pipefail
 
 source "$(dirname "$0")/exp_config.sh"
 
-if [[ -z "${TASK_FILE:-}" ]]; then
-    echo "TASK_FILE not specified" >&2
+if [[ $# -lt 3 ]]; then
+    echo "Usage: $0 <matrix_dir> <perm_path> <mult_impl> [key=value ...]" >&2
     exit 1
 fi
 
-IFS=' ' read -r MAT_DIR PERM IMPL PARAM_JSON < <(sed -n "$((SLURM_ARRAY_TASK_ID+1))p" "$TASK_FILE")
-
-if [[ -z "$MAT_DIR" || -z "$PERM" || -z "$IMPL" || -z "$PARAM_JSON" ]]; then
-    echo "Invalid task specification at index $SLURM_ARRAY_TASK_ID" >&2
-    exit 1
-fi
+MAT_DIR="$1"
+PERM="$2"
+IMPL="$3"
+shift 3
+PARAMS=("$@")
 
 if [[ ! -f "$PERM" ]]; then
     echo "Permutation file $PERM not found" >&2
@@ -41,7 +40,6 @@ fi
 
 MATRIX_NAME=$(basename "$(dirname "$MAT_DIR")")
 TECH_PARAM=$(basename "$MAT_DIR")
-PARAM_ID=$(basename "$PARAM_JSON" .json)
 
 OUTDIR="$RESULTS_DIR/Multiplication/$MATRIX_NAME/$TECH_PARAM/$IMPL"
 mkdir -p "$OUTDIR"
@@ -53,19 +51,17 @@ if [[ ! -x "$WRAPPER" ]]; then
     exit 1
 fi
 
-PARAM_SET=$(python - <<'PY'
-import json,sys
-with open(sys.argv[1]) as f:
-    cfg=json.load(f)
-print(';'.join(f"{k}={v}" for k,v in sorted(cfg.items())))
-PY
-"$PARAM_JSON")
+if (( ${#PARAMS[@]} )); then
+    PARAM_SET=$(IFS=';'; echo "${PARAMS[*]}")
+else
+    PARAM_SET=""
+fi
 
 cp "$MAT_DIR/results.csv" "$CSV"
 
 start=$(date +%s%N)
 set +e
-"$WRAPPER" "$MAT_DIR" "$PARAM_JSON"
+"$WRAPPER" "$MAT_DIR" "${PARAMS[@]}"
 STATUS=$?
 set -e
 end=$(date +%s%N)

--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -14,30 +14,34 @@
 #SBATCH --tasks=<ntasks>
 #SBATCH --cpus-per-task=<cpus-per-task>
 
-# General driver for reordering experiments. Each task reads a line from
-# $TASK_FILE containing: <matrix_path> <reorder_tech> <param_json>
+# General driver for a single reordering experiment.
+# Usage: sbatch Programs/Reorder.sbatch <matrix_path> <reorder_tech> [key=value ...]
 
 set -euo pipefail
 
 # Ensure PROJECT_ROOT, MATRIX_DIR, RESULTS_DIR
 source "$(dirname "$0")/exp_config.sh"
 
-if [[ -z "${TASK_FILE:-}" ]]; then
-    echo "TASK_FILE not specified" >&2
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <matrix_path> <reorder_tech> [key=value ...]" >&2
     exit 1
 fi
 
-# Extract arguments for this array task
-IFS=' ' read -r MATRIX TECH PARAM_JSON < <(sed -n "$((SLURM_ARRAY_TASK_ID+1))p" "$TASK_FILE")
-
-if [[ -z "$MATRIX" || -z "$TECH" || -z "$PARAM_JSON" ]]; then
-    echo "Invalid task specification at index $SLURM_ARRAY_TASK_ID" >&2
-    exit 1
-fi
+MATRIX="$1"
+TECH="$2"
+shift 2
+PARAMS=("$@")
 
 MATRIX_NAME=$(basename "$MATRIX" .mtx)
 DATASET=$(basename "$(dirname "$MATRIX")")
-PARAM_ID=$(basename "$PARAM_JSON" .json)
+
+if (( ${#PARAMS[@]} )); then
+    PARAM_SET=$(IFS=';'; echo "${PARAMS[*]}")
+    PARAM_ID=$(echo "$PARAM_SET" | tr ';' '_' | tr '=' '-')
+else
+    PARAM_SET=""
+    PARAM_ID="default"
+fi
 
 OUTDIR="$RESULTS_DIR/Reordering/$MATRIX_NAME/${TECH}_${PARAM_ID}"
 mkdir -p "$OUTDIR"
@@ -60,21 +64,11 @@ print(cfg.get(tech, {}).get('type', '1D'))
 PY
 "$TECH" "$PROJECT_ROOT/config/reorder.yml")
 
-# Convert param JSON to semicolon-separated key=value
-PARAM_SET=$(python - <<'PY'
-import json,sys
-with open(sys.argv[1]) as f:
-    cfg=json.load(f)
-print(';'.join(f"{k}={v}" for k,v in sorted(cfg.items())))
-PY
-"$PARAM_JSON")
-
 start=$(date +%s%N)
 set +e
-"$WRAPPER" "$MATRIX" "$PERM" "$PARAM_JSON"
+"$WRAPPER" "$MATRIX" "$PERM" "${PARAMS[@]}"
 STATUS=$?
 set -e
-default=0
 end=$(date +%s%N)
 TIME_MS=$(( (end - start) / 1000000 ))
 TIMESTAMP=$(date --iso-8601=seconds)

--- a/Programs/Reordering/Techniques/reordering_ro.sh
+++ b/Programs/Reordering/Techniques/reordering_ro.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# reordering_ro.sh <matrix> <out_perm> <params_json>
+# reordering_ro.sh <matrix> <out_perm> [key=value ...]
 set -euo pipefail
 
 # Load cluster environment
@@ -12,13 +12,12 @@ if [[ ! -x "$RO_BIN" ]]; then
     exit 1
 fi
 
-mode=$(python - <<'PY'
-import json,sys
-with open(sys.argv[1]) as f:
-    p=json.load(f)
-print(p.get('mode','reorder'))
-PY
-"$3")
+mode="reorder"
+for kv in "${@:3}"; do
+    case $kv in
+        mode=*) mode="${kv#mode=}" ;;
+    esac
+done
 
 flag=""
 if [[ "$mode" == "cluster" ]]; then


### PR DESCRIPTION
## Summary
- simplify Reorder.sbatch to handle one matrix/technique at a time and accept parameters as key=value pairs
- mirror the same single-task, key=value interface in Multiply.sbatch
- update reordering_ro wrapper, README, and design docs for the new submission workflow

## Testing
- `bash -n Programs/Reorder.sbatch Programs/Multiply.sbatch Programs/Reordering/Techniques/reordering_ro.sh`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e40bfd26c832192e46124823f91fa