### PR TITLE
Add sbatch launchers for reordering and multiplication jobs

### DIFF
--- a/Programs/Multiply.sbatch
+++ b/Programs/Multiply.sbatch
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-#SBATCH --job-name=<exp-name>
-#SBATCH --output=<sout_path>/<hostname>/<exp-name>/<exp-name>_%j.out
-#SBATCH --error=<sout_path>/<hostname>/<exp-name>/<exp-name>_%j.err
-
-#SBATCH --partition=<partition>
-#SBATCH --account=<account>
-#SBATCH --time=<time>
-
-#SBATCH --nodes=<nnodes>
-#SBATCH --gres=gpu:<ngpus>
-#SBATCH --tasks=<ntasks>
-#SBATCH --cpus-per-task=<cpus-per-task>
-
-
-
 # Driver for a single multiplication experiment.
 # Usage: sbatch Programs/Multiply.sbatch <matrix_dir> <perm_path> <mult_impl> [key=value ...]
 

--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-#SBATCH --job-name=<exp-name>
-#SBATCH --output=<sout_path>/<hostname>/<exp-name>/<exp-name>_%j.out
-#SBATCH --error=<sout_path>/<hostname>/<exp-name>/<exp-name>_%j.err
-
-#SBATCH --partition=<partition>
-#SBATCH --account=<account>
-#SBATCH --time=<time>
-#SBATCH --qos=<qos>  # optional
-
-#SBATCH --nodes=<nnodes>
-#SBATCH --gres=gpu:<ngpus>
-#SBATCH --tasks=<ntasks>
-#SBATCH --cpus-per-task=<cpus-per-task>
-
 # General driver for a single reordering experiment.
 # Usage: sbatch Programs/Reorder.sbatch <matrix_path> <reorder_tech> [key=value ...]
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,9 @@
 Helper utilities and setup scripts. `bootstrap.sh` installs third-party
 reorderers. `csv_helper.py` merges structural metrics into the results and
-uses SuiteSparse:GraphBLAS for sparse matrix computations. Install the Python packages
-listed in `requirements.txt` before invoking these scripts:
+uses SuiteSparse:GraphBLAS for sparse matrix computations. `launch_reordering.sh`
+submits a single reordering job, while `launch_multiply.sh` submits a
+single multiplication job given a reordered matrix directory. Install the
+Python packages listed in `requirements.txt` before invoking these scripts:
 
 ```bash
 pip install -r requirements.txt

--- a/scripts/launch_multiply.sh
+++ b/scripts/launch_multiply.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Submit a multiplication job via sbatch
+# Usage: launch_multiply.sh <matrix_dir> <mult_impl> [key=value ...]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROGRAM="$ROOT/Programs/Multiply.sbatch"
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <matrix_dir> <mult_impl> [key=value ...]" >&2
+    exit 1
+fi
+
+MAT_DIR="$1"
+IMPL="$2"
+shift 2
+PARAMS=("$@")
+
+PERM="$MAT_DIR/permutation.g"
+if [[ ! -f "$PERM" ]]; then
+    echo "Permutation file $PERM not found" >&2
+    exit 1
+fi
+
+MATRIX_NAME=$(basename "$(dirname "$MAT_DIR")")
+TECH_PARAM=$(basename "$MAT_DIR")
+
+if (( ${#PARAMS[@]} )); then
+    PARAM_SET=$(IFS=';'; echo "${PARAMS[*]}")
+    PARAM_ID=$(echo "$PARAM_SET" | tr ';' '_' | tr '=' '-')
+else
+    PARAM_ID="default"
+fi
+
+EXP_NAME="${MATRIX_NAME}_${TECH_PARAM}_${IMPL}_${PARAM_ID}"
+LOG_DIR=${LOG_DIR:-"$ROOT/logs"}
+HOST=$(hostname)
+OUT_DIR="$LOG_DIR/$HOST/$EXP_NAME"
+mkdir -p "$OUT_DIR"
+
+SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err")
+[[ -n "${PARTITION:-}" ]] && SBATCH_OPTS+=("--partition=$PARTITION")
+[[ -n "${ACCOUNT:-}" ]] && SBATCH_OPTS+=("--account=$ACCOUNT")
+[[ -n "${TIME:-}" ]] && SBATCH_OPTS+=("--time=$TIME")
+[[ -n "${QOS:-}" ]] && SBATCH_OPTS+=("--qos=$QOS")
+[[ -n "${NODES:-}" ]] && SBATCH_OPTS+=("--nodes=$NODES")
+[[ -n "${GPUS:-}" ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
+[[ -n "${NTASKS:-}" ]] && SBATCH_OPTS+=("--ntasks=$NTASKS")
+[[ -n "${CPUS_PER_TASK:-}" ]] && SBATCH_OPTS+=("--cpus-per-task=$CPUS_PER_TASK")
+
+sbatch "${SBATCH_OPTS[@]}" "$PROGRAM" "$MAT_DIR" "$PERM" "$IMPL" "${PARAMS[@]}"

--- a/scripts/launch_reordering.sh
+++ b/scripts/launch_reordering.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Submit a reordering job via sbatch
+# Usage: launch_reordering.sh <matrix_path> <reorder_tech> [key=value ...]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROGRAM="$ROOT/Programs/Reorder.sbatch"
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <matrix_path> <reorder_tech> [key=value ...]" >&2
+    exit 1
+fi
+
+MATRIX="$1"
+TECH="$2"
+shift 2
+PARAMS=("$@")
+
+if (( ${#PARAMS[@]} )); then
+    PARAM_SET=$(IFS=';'; echo "${PARAMS[*]}")
+    PARAM_ID=$(echo "$PARAM_SET" | tr ';' '_' | tr '=' '-')
+else
+    PARAM_ID="default"
+fi
+
+MATRIX_NAME=$(basename "$MATRIX" .mtx)
+EXP_NAME="${MATRIX_NAME}_${TECH}_${PARAM_ID}"
+LOG_DIR=${LOG_DIR:-"$ROOT/logs"}
+HOST=$(hostname)
+OUT_DIR="$LOG_DIR/$HOST/$EXP_NAME"
+mkdir -p "$OUT_DIR"
+
+SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err")
+[[ -n "${PARTITION:-}" ]] && SBATCH_OPTS+=("--partition=$PARTITION")
+[[ -n "${ACCOUNT:-}" ]] && SBATCH_OPTS+=("--account=$ACCOUNT")
+[[ -n "${TIME:-}" ]] && SBATCH_OPTS+=("--time=$TIME")
+[[ -n "${QOS:-}" ]] && SBATCH_OPTS+=("--qos=$QOS")
+[[ -n "${NODES:-}" ]] && SBATCH_OPTS+=("--nodes=$NODES")
+[[ -n "${GPUS:-}" ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
+[[ -n "${NTASKS:-}" ]] && SBATCH_OPTS+=("--ntasks=$NTASKS")
+[[ -n "${CPUS_PER_TASK:-}" ]] && SBATCH_OPTS+=("--cpus-per-task=$CPUS_PER_TASK")
+
+sbatch "${SBATCH_OPTS[@]}" "$PROGRAM" "$MATRIX" "$TECH" "${PARAMS[@]}"


### PR DESCRIPTION
## Summary
- remove placeholder SBATCH directives from `Programs/Reorder.sbatch` and `Programs/Multiply.sbatch`
- add `launch_multiply.sh` to submit multiplication jobs via `sbatch`
- document the new helper alongside reordering launcher

## Testing
- `bash -n Programs/Reorder.sbatch Programs/Multiply.sbatch scripts/launch_reordering.sh scripts/launch_multiply.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e42fe8f5083219443d37cbdddd2e9