### PR TITLE
Integrate matrix permutation helper into multiplication workflow

### DIFF
--- a/Programs/Multiply.sbatch
+++ b/Programs/Multiply.sbatch
@@ -26,6 +26,25 @@ fi
 MATRIX_NAME=$(basename "$(dirname "$MAT_DIR")")
 TECH_PARAM=$(basename "$MAT_DIR")
 
+CSV_SRC="$MAT_DIR/results.csv"
+DATASET=$(python - <<'PY' "$CSV_SRC"
+import sys,pandas as pd
+df=pd.read_csv(sys.argv[1])
+print(df.loc[0,'dataset'])
+PY
+)
+REORDER_TYPE=$(python - <<'PY' "$CSV_SRC"
+import sys,pandas as pd
+df=pd.read_csv(sys.argv[1])
+print(str(df.loc[0,'reorder_type']).strip().upper())
+PY
+)
+
+MTX_PATH="$PROJECT_ROOT/Raw_Matrices/$DATASET/$MATRIX_NAME.mtx"
+REORDERED="$MAT_DIR/reordered.mtx"
+trap 'rm -f "$REORDERED"' EXIT
+python "$PROJECT_ROOT/scripts/reorder_matrix.py" "$MTX_PATH" "$PERM" "$REORDER_TYPE" "$REORDERED"
+
 OUTDIR="$RESULTS_DIR/Multiplication/$MATRIX_NAME/$TECH_PARAM/$IMPL"
 mkdir -p "$OUTDIR"
 CSV="$OUTDIR/results.csv"
@@ -42,7 +61,7 @@ else
     PARAM_SET=""
 fi
 
-cp "$MAT_DIR/results.csv" "$CSV"
+cp "$CSV_SRC" "$CSV"
 
 start=$(date +%s%N)
 set +e

--- a/scripts/reorder_matrix.py
+++ b/scripts/reorder_matrix.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Apply a permutation to a Matrix Market file.
+
+The permutation file is expected to contain 1-based indices, one per line.
+Depending on ``rtype``:
+- ``1D``: Permutes only the rows of the matrix.
+- ``2D``: Applies the permutation to both rows and columns.
+
+The reordered matrix is written to ``out_path``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from scipy.io import mmread, mmwrite
+
+
+def apply_permutation(matrix: Path, perm: Path, rtype: str, out_path: Path) -> None:
+    A = mmread(matrix).tocsr()
+    p = np.loadtxt(perm, dtype=np.int64) - 1
+    if rtype.upper() == "2D":
+        A = A[p, :][:, p]
+    else:
+        A = A[p, :]
+    mmwrite(out_path, A)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reorder a matrix with a permutation")
+    parser.add_argument("matrix", type=Path, help="Path to input .mtx matrix")
+    parser.add_argument("permutation", type=Path, help="Path to permutation file")
+    parser.add_argument("rtype", choices=["1D", "2D"], help="Reordering type")
+    parser.add_argument("out", type=Path, help="Output path for reordered matrix")
+    args = parser.parse_args()
+    apply_permutation(args.matrix, args.permutation, args.rtype, args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/reorder_matrix.py` to apply 1D/2D permutations to Matrix Market files
- update `Programs/Multiply.sbatch` to generate reordered matrices on the fly and clean up temporary files

## Testing
- `python -m py_compile scripts/reorder_matrix.py`
- `scripts/reorder_matrix.py /tmp/test.mtx /tmp/perm.g 2D /tmp/out.mtx`
- `Programs/Multiply.sbatch Results/Reordering/testmatrix/tech_default Results/Reordering/testmatrix/tech_default/permutation.g dummy`


------
https://chatgpt.com/codex/tasks/task_e_688e487c6a3c83218fd42721cfb21f4c