### PR TITLE
Factor out matrix reordering from csv helper

### DIFF
--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -78,7 +78,11 @@ matrix_name,dataset,n_rows,n_cols,nnz,reorder_type,reorder_tech,reord_param_set,
 $MATRIX_NAME,$DATASET,$N_ROWS,$N_COLS,$NNZ,$REORDER_TYPE,$TECH,"$PARAM_SET",$TIME_MS,,,$STATUS,$TIMESTAMP
 CSV
 
+# Generate reordered matrix for downstream use and metrics
+REORDERED="$OUTDIR/reordered.mtx"
+python "$PROJECT_ROOT/scripts/reorder_matrix.py" "$MATRIX" "$PERM" "$REORDER_TYPE" "$REORDERED"
+
 # Post-process structural metrics
-python "$PROJECT_ROOT/scripts/csv_helper.py" "$MATRIX" "$PERM" "$CSV" || true
+python "$PROJECT_ROOT/scripts/csv_helper.py" "$REORDERED" "$CSV" || true
 
 exit $STATUS

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,10 @@
 Helper utilities and setup scripts. `bootstrap.sh` installs third-party
-reorderers. `csv_helper.py` merges structural metrics into the results and
-uses SuiteSparse:GraphBLAS for sparse matrix computations. `launch_reordering.sh`
-submits a single reordering job, while `launch_multiply.sh` submits a
-single multiplication job given a reordered matrix directory. Install the
-Python packages listed in `requirements.txt` before invoking these scripts:
+reorderers. `reorder_matrix.py` applies permutations to Matrix Market
+files, and `csv_helper.py` merges structural metrics into the results using
+SuiteSparse:GraphBLAS. `launch_reordering.sh` submits a single reordering
+job, while `launch_multiply.sh` submits a single multiplication job given a
+reordered matrix directory. Install the Python packages listed in
+`requirements.txt` before invoking these scripts:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- decouple matrix permutation logic from csv_helper and have it consume a pre-reordered matrix
- Reorder.sbatch now calls reorder_matrix.py and passes its output to csv_helper
- document new scripts in scripts/README

## Testing
- `python -m py_compile scripts/csv_helper.py`
- `bash -n Programs/Reorder.sbatch`
- `python -m py_compile scripts/reorder_matrix.py`


------
https://chatgpt.com/codex/tasks/task_e_688e4b41bfa08321a7f540911cef9b61