### PR TITLE
Refactor multiply submission to accept reordering CSV

### DIFF
--- a/Programs/Multiply.sbatch
+++ b/Programs/Multiply.sbatch
@@ -1,23 +1,28 @@
 #!/bin/bash
 
 # Driver for a single multiplication experiment.
-# Usage: sbatch Programs/Multiply.sbatch <matrix_dir> <perm_path> <mult_impl> [key=value ...]
+# Usage: sbatch Programs/Multiply.sbatch <reorder_csv> <mult_impl> [key=value ...]
 
 set -euo pipefail
 
 source "$(dirname "$0")/exp_config.sh"
 
-if [[ $# -lt 3 ]]; then
-    echo "Usage: $0 <matrix_dir> <perm_path> <mult_impl> [key=value ...]" >&2
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <reorder_csv> <mult_impl> [key=value ...]" >&2
     exit 1
 fi
 
-MAT_DIR="$1"
-PERM="$2"
-IMPL="$3"
-shift 3
+CSV_SRC="$1"
+IMPL="$2"
+shift 2
 PARAMS=("$@")
+if [[ ! -f "$CSV_SRC" ]]; then
+    echo "CSV $CSV_SRC not found" >&2
+    exit 1
+fi
 
+MAT_DIR="$(dirname "$CSV_SRC")"
+PERM="$MAT_DIR/permutation.g"
 if [[ ! -f "$PERM" ]]; then
     echo "Permutation file $PERM not found" >&2
     exit 1
@@ -25,8 +30,6 @@ fi
 
 MATRIX_NAME=$(basename "$(dirname "$MAT_DIR")")
 TECH_PARAM=$(basename "$MAT_DIR")
-
-CSV_SRC="$MAT_DIR/results.csv"
 DATASET=$(python - <<'PY' "$CSV_SRC"
 import sys,pandas as pd
 df=pd.read_csv(sys.argv[1])
@@ -41,13 +44,13 @@ PY
 )
 
 MTX_PATH="$PROJECT_ROOT/Raw_Matrices/$DATASET/$MATRIX_NAME.mtx"
-REORDERED="$MAT_DIR/reordered.mtx"
-trap 'rm -f "$REORDERED"' EXIT
-python "$PROJECT_ROOT/scripts/reorder_matrix.py" "$MTX_PATH" "$PERM" "$REORDER_TYPE" "$REORDERED"
 
 OUTDIR="$RESULTS_DIR/Multiplication/$MATRIX_NAME/$TECH_PARAM/$IMPL"
 mkdir -p "$OUTDIR"
 CSV="$OUTDIR/results.csv"
+REORDERED="$OUTDIR/reordered.mtx"
+trap 'rm -f "$REORDERED"' EXIT
+python "$PROJECT_ROOT/scripts/reorder_matrix.py" "$MTX_PATH" "$PERM" "$REORDER_TYPE" "$REORDERED"
 
 WRAPPER="$PROJECT_ROOT/Programs/Multiplication/Techniques/operation_${IMPL}.sh"
 if [[ ! -x "$WRAPPER" ]]; then
@@ -65,7 +68,7 @@ cp "$CSV_SRC" "$CSV"
 
 start=$(date +%s%N)
 set +e
-"$WRAPPER" "$MAT_DIR" "${PARAMS[@]}"
+"$WRAPPER" "$OUTDIR" "${PARAMS[@]}"
 STATUS=$?
 set -e
 end=$(date +%s%N)

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ sbatch Programs/Reorder.sbatch Raw_Matrices/TEST/matrix.mtx ro mode=cluster
 # Multiply the reordered matrix with a given kernel
 sbatch --dependency=afterok:<REORDER_JOBID> \
        Programs/Multiply.sbatch \
-       Results/Reordering/TEST/matrix/ro_mode-cluster \
-       Results/Reordering/TEST/matrix/ro_mode-cluster/permutation.g \
+       Results/Reordering/TEST/matrix/ro_mode-cluster/results.csv \
        cusparse alpha=1.0
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@ reorderers. `reorder_matrix.py` applies permutations to Matrix Market
 files, and `csv_helper.py` merges structural metrics into the results using
 SuiteSparse:GraphBLAS. `launch_reordering.sh` submits a single reordering
 job, while `launch_multiply.sh` submits a single multiplication job given a
-reordered matrix directory. Install the Python packages listed in
+reordered results CSV. Install the Python packages listed in
 `requirements.txt` before invoking these scripts:
 
 ```bash

--- a/scripts/launch_multiply.sh
+++ b/scripts/launch_multiply.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
 # Submit a multiplication job via sbatch
-# Usage: launch_multiply.sh <matrix_dir> <mult_impl> [key=value ...]
+# Usage: launch_multiply.sh <reorder_csv> <mult_impl> [key=value ...]
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROGRAM="$ROOT/Programs/Multiply.sbatch"
 
 if [[ $# -lt 2 ]]; then
-    echo "Usage: $0 <matrix_dir> <mult_impl> [key=value ...]" >&2
+    echo "Usage: $0 <reorder_csv> <mult_impl> [key=value ...]" >&2
     exit 1
 fi
 
-MAT_DIR="$1"
+CSV_SRC="$1"
 IMPL="$2"
 shift 2
 PARAMS=("$@")
 
+if [[ ! -f "$CSV_SRC" ]]; then
+    echo "CSV $CSV_SRC not found" >&2
+    exit 1
+fi
+
+MAT_DIR="$(dirname "$CSV_SRC")"
 PERM="$MAT_DIR/permutation.g"
 if [[ ! -f "$PERM" ]]; then
     echo "Permutation file $PERM not found" >&2
@@ -48,4 +54,4 @@ SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--er
 [[ -n "${NTASKS:-}" ]] && SBATCH_OPTS+=("--ntasks=$NTASKS")
 [[ -n "${CPUS_PER_TASK:-}" ]] && SBATCH_OPTS+=("--cpus-per-task=$CPUS_PER_TASK")
 
-sbatch "${SBATCH_OPTS[@]}" "$PROGRAM" "$MAT_DIR" "$PERM" "$IMPL" "${PARAMS[@]}"
+sbatch "${SBATCH_OPTS[@]}" "$PROGRAM" "$CSV_SRC" "$IMPL" "${PARAMS[@]}"


### PR DESCRIPTION
## Summary
- Rework `Programs/Multiply.sbatch` to accept a reordering results CSV, stage the permuted matrix in the multiply output directory, and update multiply metrics
- Update `launch_multiply.sh` and docs to use the CSV-based interface

## Testing
- `bash -n Programs/Multiply.sbatch`
- `bash -n scripts/launch_multiply.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e4e95e7008321bf008a439540f27e