### PR TITLE
Add identity reordering wrapper and test

### DIFF
--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -41,14 +41,14 @@ if [[ ! -x "$WRAPPER" ]]; then
 fi
 
 # Determine reordering type (1D vs 2D)
-REORDER_TYPE=$(python - <<'PY'
+REORDER_TYPE=$(python - "$TECH" "$PROJECT_ROOT/config/reorder.yml" <<'PY'
 import sys, yaml
 tech, cfg_path = sys.argv[1], sys.argv[2]
 with open(cfg_path) as f:
     cfg = yaml.safe_load(f)
 print(cfg.get(tech, {}).get('type', '1D'))
 PY
-"$TECH" "$PROJECT_ROOT/config/reorder.yml")
+)
 
 start=$(date +%s%N)
 set +e
@@ -60,7 +60,7 @@ TIME_MS=$(( (end - start) / 1000000 ))
 TIMESTAMP=$(date --iso-8601=seconds)
 
 # Extract basic matrix info
-read N_ROWS N_COLS NNZ < <(python - <<'PY'
+read N_ROWS N_COLS NNZ < <(python - "$MATRIX" <<'PY'
 import sys
 with open(sys.argv[1]) as f:
     header=f.readline()
@@ -70,7 +70,7 @@ with open(sys.argv[1]) as f:
         print(*line.split())
         break
 PY
-"$MATRIX")
+)
 
 # Write initial CSV row
 cat > "$CSV" <<CSV
@@ -80,7 +80,9 @@ CSV
 
 # Generate reordered matrix for downstream use and metrics
 REORDERED="$OUTDIR/reordered.mtx"
+set +e
 python "$PROJECT_ROOT/scripts/reorder_matrix.py" "$MATRIX" "$PERM" "$REORDER_TYPE" "$REORDERED"
+set -e
 
 # Post-process structural metrics
 python "$PROJECT_ROOT/scripts/csv_helper.py" "$REORDERED" "$CSV" || true

--- a/Programs/Reordering/Techniques/reordering_identity.sh
+++ b/Programs/Reordering/Techniques/reordering_identity.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# reordering_identity.sh <matrix> <out_perm> [key=value ...]
+set -euo pipefail
+
+# Load cluster environment
+source "$(dirname "$0")/../../exp_config.sh"
+
+python - <<'PY' "$1" "$2"
+import sys
+mtx_path, out_path = sys.argv[1:3]
+with open(mtx_path) as f:
+    for line in f:
+        if line.startswith('%'):
+            continue
+        nrows = int(line.split()[0])
+        break
+with open(out_path, 'w') as out:
+    for i in range(1, nrows + 1):
+        out.write(f"{i}\n")
+PY

--- a/tests/test_identity_reorder.py
+++ b/tests/test_identity_reorder.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_identity_reorder(tmp_path):
+    # Create a tiny 2x2 diagonal matrix in Matrix Market format
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    mtx = dataset / "matrix.mtx"
+    mtx.write_text("""%%MatrixMarket matrix coordinate real general\n2 2 2\n1 1 1\n2 2 1\n""")
+
+    # Run the reordering driver with our identity wrapper
+    env = os.environ.copy()
+    results_dir = tmp_path / "results"
+    env["RESULTS_DIR"] = str(results_dir)
+    subprocess.run(
+        ["bash", "Programs/Reorder.sbatch", str(mtx), "identity"],
+        check=True,
+        env=env,
+    )
+
+    # Verify that the permutation and results CSV were produced
+    out_dir = results_dir / "Reordering" / "matrix" / "identity_default"
+    perm = (out_dir / "permutation.g").read_text().split()
+    assert perm == ["1", "2"]
+
+    csv = out_dir / "results.csv"
+    assert csv.is_file()
+    df = pd.read_csv(csv)
+    assert df.loc[0, "reorder_tech"] == "identity"
+    assert df.loc[0, "exit_code"] == 0


### PR DESCRIPTION
## Summary
- add an `identity` reordering wrapper that emits an identity permutation
- update `Reorder.sbatch` to correctly pass config paths and keep running if matrix post-processing fails
- test that running the `identity` technique through `Reorder.sbatch` writes a result CSV

## Testing
- `pytest tests/test_identity_reorder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e539768ec83219c35b96282f53e08