### PR TITLE
Refactor sbatch option handling

### DIFF
--- a/config/multiply.yml
+++ b/config/multiply.yml
@@ -1,4 +1,7 @@
 # Placeholder multiplication parameter sets
 cucsrspmm:
-  - param: default
+  gpus: 1
+  time: "00:10:00"
+  params:
+    - param: default
 

--- a/config/reorder.yml
+++ b/config/reorder.yml
@@ -1,13 +1,19 @@
 # Placeholder reordering parameter sets
 rcm:
   type: 2D
+  gpus: 0
+  time: "00:10:00"
   params:
     - param: default
 ro:
   type: 1D
+  gpus: 0
+  time: "00:05:00"
   params:
     - param: default
 identity:
   type: 1D
+  gpus: 0
+  time: "00:01:00"
   params:
     - param: default

--- a/config/sbatch.yml
+++ b/config/sbatch.yml
@@ -1,0 +1,8 @@
+partition: default
+account: default
+qos: normal
+nodes: 1
+ntasks: 1
+cpus_per_task: 1
+mem: 0
+constraint: ""

--- a/scripts/launch_multiply.sh
+++ b/scripts/launch_multiply.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROGRAM="$ROOT/Programs/Multiply.sbatch"
+SBATCH_CFG="$ROOT/config/sbatch.yml"
 
 if [[ $# -lt 2 ]]; then
     echo "Usage: $0 <reorder_csv> <mult_impl> [key=value ...]" >&2
@@ -44,14 +45,31 @@ HOST=$(hostname)
 OUT_DIR="$LOG_DIR/$HOST/$EXP_NAME"
 mkdir -p "$OUT_DIR"
 
-SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err")
-[[ -n "${PARTITION:-}" ]] && SBATCH_OPTS+=("--partition=$PARTITION")
-[[ -n "${ACCOUNT:-}" ]] && SBATCH_OPTS+=("--account=$ACCOUNT")
-[[ -n "${TIME:-}" ]] && SBATCH_OPTS+=("--time=$TIME")
-[[ -n "${QOS:-}" ]] && SBATCH_OPTS+=("--qos=$QOS")
-[[ -n "${NODES:-}" ]] && SBATCH_OPTS+=("--nodes=$NODES")
-[[ -n "${GPUS:-}" ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
-[[ -n "${NTASKS:-}" ]] && SBATCH_OPTS+=("--ntasks=$NTASKS")
-[[ -n "${CPUS_PER_TASK:-}" ]] && SBATCH_OPTS+=("--cpus-per-task=$CPUS_PER_TASK")
+# Base SBATCH options from global config
+mapfile -t CFG_OPTS < <(python - "$SBATCH_CFG" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    cfg = yaml.safe_load(f) or {}
+for k, v in cfg.items():
+    if v in (None, ""):
+        continue
+    print(f"--{k.replace('_','-')}={v}")
+PY
+)
+
+SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err" "${CFG_OPTS[@]}")
+
+# Time and GPU usage from multiplication config
+read GPUS TIME < <(python - "$IMPL" "$ROOT/config/multiply.yml" <<'PY'
+import sys, yaml
+impl, path = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    cfg = yaml.safe_load(f) or {}
+info = cfg.get(impl, {})
+print(info.get('gpus', 0) or 0, info.get('time', ''))
+PY
+)
+[[ "$GPUS" != 0 ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
+[[ -n "$TIME" ]] && SBATCH_OPTS+=("--time=$TIME")
 
 sbatch "${SBATCH_OPTS[@]}" "$PROGRAM" "$CSV_SRC" "$IMPL" "${PARAMS[@]}"

--- a/scripts/launch_reordering.sh
+++ b/scripts/launch_reordering.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROGRAM="$ROOT/Programs/Reorder.sbatch"
+SBATCH_CFG="$ROOT/config/sbatch.yml"
 
 if [[ $# -lt 2 ]]; then
     echo "Usage: $0 <matrix_path> <reorder_tech> [key=value ...]" >&2
@@ -30,14 +31,31 @@ HOST=$(hostname)
 OUT_DIR="$LOG_DIR/$HOST/$EXP_NAME"
 mkdir -p "$OUT_DIR"
 
-SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err")
-[[ -n "${PARTITION:-}" ]] && SBATCH_OPTS+=("--partition=$PARTITION")
-[[ -n "${ACCOUNT:-}" ]] && SBATCH_OPTS+=("--account=$ACCOUNT")
-[[ -n "${TIME:-}" ]] && SBATCH_OPTS+=("--time=$TIME")
-[[ -n "${QOS:-}" ]] && SBATCH_OPTS+=("--qos=$QOS")
-[[ -n "${NODES:-}" ]] && SBATCH_OPTS+=("--nodes=$NODES")
-[[ -n "${GPUS:-}" ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
-[[ -n "${NTASKS:-}" ]] && SBATCH_OPTS+=("--ntasks=$NTASKS")
-[[ -n "${CPUS_PER_TASK:-}" ]] && SBATCH_OPTS+=("--cpus-per-task=$CPUS_PER_TASK")
+# Base SBATCH options from global config
+mapfile -t CFG_OPTS < <(python - "$SBATCH_CFG" <<'PY'
+import sys, yaml
+with open(sys.argv[1]) as f:
+    cfg = yaml.safe_load(f) or {}
+for k, v in cfg.items():
+    if v in (None, ""):
+        continue
+    print(f"--{k.replace('_','-')}={v}")
+PY
+)
+
+SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err" "${CFG_OPTS[@]}")
+
+# Time and GPU usage from reordering config
+read GPUS TIME < <(python - "$TECH" "$ROOT/config/reorder.yml" <<'PY'
+import sys, yaml
+tech, path = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    cfg = yaml.safe_load(f) or {}
+info = cfg.get(tech, {})
+print(info.get('gpus', 0) or 0, info.get('time', ''))
+PY
+)
+[[ "$GPUS" != 0 ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
+[[ -n "$TIME" ]] && SBATCH_OPTS+=("--time=$TIME")
 
 sbatch "${SBATCH_OPTS[@]}" "$PROGRAM" "$MATRIX" "$TECH" "${PARAMS[@]}"


### PR DESCRIPTION
## Summary
- centralize shared sbatch options in new `config/sbatch.yml`
- load sbatch options from config in `launch_reordering.sh` and `launch_multiply.sh`
- drive per-task GPU/time settings from `config/reorder.yml` and `config/multiply.yml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e579be1748321a0f91eae7bf67226