### PR TITLE
Use yq and bash helpers for configs

### DIFF
--- a/Programs/Multiply.sbatch
+++ b/Programs/Multiply.sbatch
@@ -30,18 +30,15 @@ fi
 
 MATRIX_NAME=$(basename "$(dirname "$MAT_DIR")")
 TECH_PARAM=$(basename "$MAT_DIR")
-DATASET=$(python - <<'PY' "$CSV_SRC"
-import sys,pandas as pd
-df=pd.read_csv(sys.argv[1])
-print(df.loc[0,'dataset'])
-PY
-)
-REORDER_TYPE=$(python - <<'PY' "$CSV_SRC"
-import sys,pandas as pd
-df=pd.read_csv(sys.argv[1])
-print(str(df.loc[0,'reorder_type']).strip().upper())
-PY
-)
+
+csv_get() {
+    local file="$1" col="$2"
+    local idx=$(awk -F, -v c="$col" 'NR==1{for(i=1;i<=NF;i++) if($i==c){print i; exit}}' "$file")
+    awk -F, -v i="$idx" 'NR==2{print $i}' "$file"
+}
+
+DATASET=$(csv_get "$CSV_SRC" "dataset")
+REORDER_TYPE=$(csv_get "$CSV_SRC" "reorder_type" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
 
 MTX_PATH="$PROJECT_ROOT/Raw_Matrices/$DATASET/$MATRIX_NAME.mtx"
 
@@ -75,17 +72,7 @@ end=$(date +%s%N)
 TIME_MS=$(( (end - start) / 1000000 ))
 TIMESTAMP=$(date --iso-8601=seconds)
 
-python - <<'PY' "$CSV" "$IMPL" "$PARAM_SET" "$TIME_MS" "$STATUS" "$TIMESTAMP"
-import sys,pandas as pd
-csv,impl,param_set,time_ms,status,timestamp=sys.argv[1:7]
-df=pd.read_csv(csv)
-df['mult_type']=impl
-df['mult_param_set']=param_set
-df['mult_time_ms']=float(time_ms)
-df['exit_code']=int(status)
-df['timestamp']=timestamp
-df.to_csv(csv,index=False)
-PY
+python "$PROJECT_ROOT/scripts/update_csv.py" "$CSV" "$IMPL" "$PARAM_SET" "$TIME_MS" "$STATUS" "$TIMESTAMP"
 
 # ------------------------------------------------------------
 # Cleanup

--- a/Programs/Reorder.sbatch
+++ b/Programs/Reorder.sbatch
@@ -41,14 +41,7 @@ if [[ ! -x "$WRAPPER" ]]; then
 fi
 
 # Determine reordering type (1D vs 2D)
-REORDER_TYPE=$(python - "$TECH" "$PROJECT_ROOT/config/reorder.yml" <<'PY'
-import sys, yaml
-tech, cfg_path = sys.argv[1], sys.argv[2]
-with open(cfg_path) as f:
-    cfg = yaml.safe_load(f)
-print(cfg.get(tech, {}).get('type', '1D'))
-PY
-)
+REORDER_TYPE=$(yq --arg tech "$TECH" -r '.[$tech].type // "1D"' "$PROJECT_ROOT/config/reorder.yml")
 
 start=$(date +%s%N)
 set +e
@@ -60,17 +53,7 @@ TIME_MS=$(( (end - start) / 1000000 ))
 TIMESTAMP=$(date --iso-8601=seconds)
 
 # Extract basic matrix info
-read N_ROWS N_COLS NNZ < <(python - "$MATRIX" <<'PY'
-import sys
-with open(sys.argv[1]) as f:
-    header=f.readline()
-    for line in f:
-        if line.startswith('%'):
-            continue
-        print(*line.split())
-        break
-PY
-)
+read N_ROWS N_COLS NNZ < <(awk 'NR>1 && !/^%/ {print $1, $2, $3; exit}' "$MATRIX")
 
 # Write initial CSV row
 cat > "$CSV" <<CSV

--- a/Programs/Reordering/Techniques/reordering_identity.sh
+++ b/Programs/Reordering/Techniques/reordering_identity.sh
@@ -5,16 +5,5 @@ set -euo pipefail
 # Load cluster environment
 source "$(dirname "$0")/../../exp_config.sh"
 
-python - <<'PY' "$1" "$2"
-import sys
-mtx_path, out_path = sys.argv[1:3]
-with open(mtx_path) as f:
-    for line in f:
-        if line.startswith('%'):
-            continue
-        nrows = int(line.split()[0])
-        break
-with open(out_path, 'w') as out:
-    for i in range(1, nrows + 1):
-        out.write(f"{i}\n")
-PY
+nrows=$(awk 'NR>1 && !/^%/ {print $1; exit}' "$1")
+seq 1 "$nrows" > "$2"

--- a/scripts/launch_multiply.sh
+++ b/scripts/launch_multiply.sh
@@ -46,29 +46,16 @@ OUT_DIR="$LOG_DIR/$HOST/$EXP_NAME"
 mkdir -p "$OUT_DIR"
 
 # Base SBATCH options from global config
-mapfile -t CFG_OPTS < <(python - "$SBATCH_CFG" <<'PY'
-import sys, yaml
-with open(sys.argv[1]) as f:
-    cfg = yaml.safe_load(f) or {}
-for k, v in cfg.items():
-    if v in (None, ""):
-        continue
-    print(f"--{k.replace('_','-')}={v}")
-PY
+mapfile -t CFG_OPTS < <(
+    yq -r 'to_entries | map(select(.value != null and .value != "")) | .[] |
+    "--" + (.key|gsub("_";"-")) + "=" + (.value|tostring)' "$SBATCH_CFG"
 )
 
 SBATCH_OPTS=("--job-name=$EXP_NAME" "--output=$OUT_DIR/${EXP_NAME}_%j.out" "--error=$OUT_DIR/${EXP_NAME}_%j.err" "${CFG_OPTS[@]}")
 
 # Time and GPU usage from multiplication config
-read GPUS TIME < <(python - "$IMPL" "$ROOT/config/multiply.yml" <<'PY'
-import sys, yaml
-impl, path = sys.argv[1], sys.argv[2]
-with open(path) as f:
-    cfg = yaml.safe_load(f) or {}
-info = cfg.get(impl, {})
-print(info.get('gpus', 0) or 0, info.get('time', ''))
-PY
-)
+GPUS=$(yq --arg impl "$IMPL" -r '.[$impl].gpus // 0' "$ROOT/config/multiply.yml")
+TIME=$(yq --arg impl "$IMPL" -r '.[$impl].time // ""' "$ROOT/config/multiply.yml")
 [[ "$GPUS" != 0 ]] && SBATCH_OPTS+=("--gres=gpu:$GPUS")
 [[ -n "$TIME" ]] && SBATCH_OPTS+=("--time=$TIME")
 

--- a/scripts/update_csv.py
+++ b/scripts/update_csv.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import sys
+import pandas as pd
+
+csv, impl, param_set, time_ms, status, timestamp = sys.argv[1:7]
+
+df = pd.read_csv(csv)
+df['mult_type'] = impl
+df['mult_param_set'] = param_set
+df['mult_time_ms'] = float(time_ms)
+df['exit_code'] = int(status)
+df['timestamp'] = timestamp
+
+df.to_csv(csv, index=False)


### PR DESCRIPTION
## Summary
- Replace inline Python YAML parsing in launch scripts with `yq`
- Simplify sbatch drivers to use `yq`, `awk`, and bash functions
- Add small helper `update_csv.py` for multiplying results CSV updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e7d0380483219a7e18a2182f5863